### PR TITLE
TritonDataCenter/node-sshpk-agent#26 sign reqs should only include rsa-sha2-256 flag if key is RSA

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -137,11 +137,14 @@ Client.prototype.sign = function (key, data, opts, cb) {
 	assert.func(cb, 'callback');
 	var timeout = opts.timeout || this.timeout;
 
+	var flags = [];
+	if (key.type === 'rsa')
+		flags.push('rsa-sha2-256');
 	var frame = {
 		type: 'sign-request',
 		publicKey: key.toBuffer('rfc4253'),
 		data: data,
-		flags: ['rsa-sha2-256']
+		flags: flags
 	};
 	var resps = ['failure', 'sign-response'];
 


### PR DESCRIPTION
Hard to add a test for this since the OpenSSH agent accepts this flag for EC keys just fine (and ignores it).

Ran `make check` and `make test` though