### PR TITLE
TritonDataCenter/node-sshpk-agent#28 agent extension payloads are not strings

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -163,9 +163,13 @@ function writeClientFrame(obj) {
 	case 'extension':
 		buf.writeUInt8(27);
 		assert.string(obj.extension, 'extension');
-		assert.buffer(obj.data, 'data');
+		assert.optionalBuffer(obj.data, 'data');
+		assert.optionalBuffer(obj.remainder, 'remainder');
 		buf.writeString(obj.extension);
-		buf.writeBuffer(obj.data);
+		if (obj.data)
+			buf.writeBuffer(obj.data);
+		if (obj.remainder)
+			buf.write(obj.remainder);
 		break;
 	default:
 		throw (new AgentProtocolError(util.format('Invalid outgoing ' +


### PR DESCRIPTION
See bug for info. This isn't really public API, but it's still wrong and I've used it for a few tools before.